### PR TITLE
Update to mqtt extension listing

### DIFF
--- a/repository.json
+++ b/repository.json
@@ -356,10 +356,24 @@
     "extensions": [{
         "author": "Floris Jan Galesloot",
         "display_name": "MQTT Extension",
-        "description": "Extension to publish Roon status to MQTT Broker",
+        "description": "Extension to integrate Roon with home automation system using the MQTT protocol",
         "repository": {
             "type": "git",
             "url": "https://github.com/fjgalesloot/roon-extension-mqtt.git"
+            "image": {
+                "repo": "fjgalesloot/roon-extension-mqtt",
+                "tags": {
+                    "amd64": "latest"
+                },
+                "binds": [
+                    "/usr/src/app/config/config.json"
+                ],	
+                "options": {
+                    "binds": [
+                        "/usr/src/app/config/ca.pem:Local CA Certificate file"
+                    ]
+                }
+            }
         }
     }],
     "repository": { "url": "" }

--- a/repository.json
+++ b/repository.json
@@ -356,7 +356,7 @@
     "extensions": [{
         "author": "Floris Jan Galesloot",
         "display_name": "MQTT Extension",
-        "description": "Extension to integrate Roon with home automation system using the MQTT protocol",
+        "description": "Integrate Roon into your home automation system using the MQTT protocol",
         "repository": {
             "type": "git",
             "url": "https://github.com/fjgalesloot/roon-extension-mqtt.git"

--- a/repository.json
+++ b/repository.json
@@ -370,7 +370,7 @@
                 ],	
                 "options": {
                     "binds": [
-                        "/usr/src/app/config/ca.pem:Local CA Certificate file"
+                        "/usr/src/app/config/:Config folder"
                     ]
                 }
             }


### PR DESCRIPTION
I added a docker image for the extension and modified the description to better reflect the possibilities of the extension.

I don't know if I used `bind` within `image.options` correctly. For a mqtts session with valid certificates, a CA certificate file should be available in the extension. I tried to accomplish this by using the `image.options.bind`, so users can add a local ca-file mounted in the docker image to `/usr/src/app/config/ca.pem`. Is that the way `image.options.bind` works?