### PR TITLE
Add roon tradfri

### DIFF
--- a/repository.json
+++ b/repository.json
@@ -180,7 +180,7 @@
         "description": "Turn on/off Ikea Tradfri plug devices depending on zone state(playing / not playing)",
         "repository": {
             "type": "git",
-            "url": "git+https://github.com/HasseJohansen/roon-extension-ikea-tradfri.git#0.0.2"
+            "url": "git+https://github.com/HasseJohansen/roon-extension-ikea-tradfri.git#0.0.3"
         }
     }],
     "repository": { "url": "" }

--- a/repository.json
+++ b/repository.json
@@ -173,6 +173,15 @@
                 ]
             }
         }
+    },
+    {
+        "author": "Hasse Hagen Johansen",
+        "display_name": "Roon Tradfri",
+        "description": "Turn on/off Ikea Tradfri plug devices depending on zone state(playing / not playing)",
+        "repository": {
+            "type": "git",
+            "url": "git+https://github.com/HasseJohansen/roon-extension-ikea-tradfri.git#0.0.2"
+        }
     }],
     "repository": { "url": "" }
 },

--- a/repository.json
+++ b/repository.json
@@ -180,7 +180,7 @@
         "description": "Turn on/off Ikea Tradfri plug devices depending on zone state(playing / not playing)",
         "repository": {
             "type": "git",
-            "url": "git+https://github.com/HasseJohansen/roon-extension-ikea-tradfri.git#0.0.5"
+            "url": "git+https://github.com/HasseJohansen/roon-extension-ikea-tradfri.git#0.0.6"
         }
     }],
     "repository": { "url": "" }

--- a/repository.json
+++ b/repository.json
@@ -180,7 +180,7 @@
         "description": "Turn on/off Ikea Tradfri plug devices depending on zone state(playing / not playing)",
         "repository": {
             "type": "git",
-            "url": "git+https://github.com/HasseJohansen/roon-extension-ikea-tradfri.git#0.0.3"
+            "url": "git+https://github.com/HasseJohansen/roon-extension-ikea-tradfri.git#0.0.4"
         }
     }],
     "repository": { "url": "" }

--- a/repository.json
+++ b/repository.json
@@ -180,7 +180,7 @@
         "description": "Turn on/off Ikea Tradfri plug devices depending on zone state(playing / not playing)",
         "repository": {
             "type": "git",
-            "url": "git+https://github.com/HasseJohansen/roon-extension-ikea-tradfri.git#0.0.4"
+            "url": "git+https://github.com/HasseJohansen/roon-extension-ikea-tradfri.git#0.0.5"
         }
     }],
     "repository": { "url": "" }


### PR DESCRIPTION
Add roon-extension-ikea-tradfri for controling an Ikea Power plug depedning on the playing state of a zone

See: https://github.com/HasseJohansen/roon-extension-ikea-tradfri