### PR TITLE
Added roon-extension-rheos

### DIFF
--- a/repository.json
+++ b/repository.json
@@ -87,6 +87,22 @@
             "url": "https://github.com/docbobo/roon-extension-denon.git"
         }
     },
+    {  
+        "author": "Linvale",
+        "display_name": "Rheos",
+        "description": "Connect and Control Denon/Marantz Heos players from Roon",
+        "image": {
+            "repo": "rheos/roon-extension-rheos",
+            "tags": {
+                "amd64": "latest",
+                "arm": "latest",
+                "arm64": "latest"
+            },
+            "binds": [
+                "/home/node/config.json"
+            ]
+        }   
+    },
     {
         "author": "Doc Bobo",
         "display_name": "Arcam AVR390/550/850/AV860/SR250",
@@ -247,7 +263,8 @@
                 "/usr/src/app/config.json"
             ]
         }
-    }],
+    }]
+    ,
     "repository": { "url": "" }
 },
 {


### PR DESCRIPTION
Jan,

Realize this is difficult to test without Heos Players. Limited "beta testing" but this is working well on my systems and I have tested on various devices. If you accept into the repo I will update as a "pre-release:    v 0.5-00 " and harmonize across docker and GitHub and NPM. I'll then create a new entry in the Community to notify of availability.

Any thoughts and or feedback appreciated. I'll also give some comments on the extension generator and the docker learning. A major help would be to update the standard linux/node image to one that's more to updated. You'll see I settled on the latest alpine based on my testing.

Added in device control: 


        "author": "Linvale",
        "display_name": "Rheos",
        "description": "Connect and Control Denon/Marantz Heos players from Roon",
        "image": {
            "repo": "rheos/roon-extension-rheos",
            "tags": {
                "amd64": "latest",
                "arm": "latest",
                "arm64": "latest"
            },
            "binds": [
                "/home/node/config.json"
            ]
        }

