### PR TITLE
Add Roon Knob extension to Remote Control category

### DIFF
--- a/repository.json
+++ b/repository.json
@@ -1,5 +1,5 @@
 {
-    "version": "1.0.18",
+    "version": "1.0.19",
     "categories": [{
         "display_name": "System",
         "extensions": [{

--- a/repository.json
+++ b/repository.json
@@ -323,6 +323,28 @@
                     ]
                 }
             }
+        },
+        {
+            "author": "Muness",
+            "display_name": "Roon Knob",
+            "description": "Hardware volume knob for Roon with ESP32-S3 touchscreen displaying now-playing artwork and track info",
+            "image": {
+                "repo": "muness/roon-extension-knob",
+                "tags": {
+                    "amd64": "latest",
+                    "arm": "latest",
+                    "arm64": "latest"
+                },
+                "binds": [
+                    "/home/node/app/data/config.json"
+                ],
+                "options": {
+                    "env": {
+                        "PORT": "8088:HTTP Port",
+                        "TZ": ":Time Zone"
+                    }
+                }
+            }
         }]
     },
     {


### PR DESCRIPTION
## Summary
- Adds Roon Knob to the Remote Control category
- Hardware volume knob for Roon with ESP32-S3 touchscreen displaying now-playing artwork and track info

## Extension Details
- **Author**: Muness
- **Docker Image**: `muness/roon-extension-knob`
- **GitHub**: https://github.com/muness/roon-knob
- **Community Discussion**: https://community.roonlabs.com/t/50-diy-esp32-s3-knob-as-roon-desk-controller/311363/64
- **Architectures**: amd64, arm, arm64

🤖 Generated with [Claude Code](https://claude.com/claude-code)