### PR TITLE
fix: Update Roon Knob config persistence

### DIFF
--- a/repository.json
+++ b/repository.json
@@ -329,7 +329,7 @@
             "display_name": "Roon Knob",
             "description": "Hardware volume knob for Roon with ESP32-S3 touchscreen displaying now-playing artwork and track info",
             "image": {
-                "repo": "muness/unified-hifi-control",
+                "repo": "muness/roon-extension-knob",
                 "tags": {
                     "amd64": "latest",
                     "arm": "latest",

--- a/repository.json
+++ b/repository.json
@@ -329,15 +329,20 @@
             "display_name": "Roon Knob",
             "description": "Hardware volume knob for Roon with ESP32-S3 touchscreen displaying now-playing artwork and track info",
             "image": {
-                "repo": "muness/roon-extension-knob",
+                "repo": "muness/unified-hifi-control",
                 "tags": {
                     "amd64": "latest",
                     "arm": "latest",
                     "arm64": "latest"
                 },
-                "binds": [
-                    "/home/node/app/data/config.json"
-                ],
+                "config": {
+                    "Volumes": {
+                        "/data": {}
+                    },
+                    "HostConfig": {
+                        "Binds": [ "roon-knob-data:/data" ]
+                    }
+                },
                 "options": {
                     "env": {
                         "PORT": "8088:HTTP Port",


### PR DESCRIPTION
Two fixes:

1. Config persistence:

- Before: binds /home/node/app/data/config.json (wrong path, single file)
- After: volume roon-knob-data:/data (correct path, full directory)

This fixes config loss on restart/update cycles. The /data directory contains Roon auth tokens and other state that must persist.

Fixes: cloud-atlas-ai/unified-hifi-control#39